### PR TITLE
feat(load-generator): first version of a playwright based load generator

### DIFF
--- a/load-generator/.containerignore
+++ b/load-generator/.containerignore
@@ -1,0 +1,9 @@
+/node_modules
+
+# Playwright
+/test-results.json
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+/playwright/.auth/

--- a/load-generator/.gitignore
+++ b/load-generator/.gitignore
@@ -1,0 +1,9 @@
+/node_modules
+
+# Playwright
+/test-results.json
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+/playwright/.auth/

--- a/load-generator/Containerfile
+++ b/load-generator/Containerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/playwright:v1.61.1-resolute
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+CMD ["npm", "test"]

--- a/load-generator/README.md
+++ b/load-generator/README.md
@@ -1,0 +1,21 @@
+# Container image to run a lightweight/simplified performance test with playwright
+
+This does not replace any 'real' performance tests / our Red Hat performance team.
+
+The goal here is to make results reproducable and testable on smaller test environments.
+
+## Run it locally
+
+```shell
+cd worker
+npm install
+export RHDH_URL=...
+npm test
+```
+
+## Run it on a cluster
+
+```shell
+podman build . --tag ...
+# TODO ...
+```

--- a/load-generator/package-lock.json
+++ b/load-generator/package-lock.json
@@ -1,0 +1,83 @@
+{
+  "name": "tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tests",
+      "version": "1.0.0",
+      "dependencies": {
+        "playwright": "^1.61.1",
+        "playwright-core": "^1.61.1"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.61.1",
+        "@types/node": "^26.0.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/load-generator/package.json
+++ b/load-generator/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "tests",
+  "version": "1.0.0",
+  "description": "",
+  "private": true,
+  "type": "commonjs",
+  "dependencies": {
+    "playwright": "^1.61.1",
+    "playwright-core": "^1.61.1"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.61.1",
+    "@types/node": "^26.0.1"
+  },
+  "scripts": {
+    "install-browser": "playwright install chromium",
+    "playwright": "playwright",
+    "analyse": "node scripts/analyse.mts",
+    "test": "playwright test && npm run analyse"
+  }
+}

--- a/load-generator/playwright.config.ts
+++ b/load-generator/playwright.config.ts
@@ -1,0 +1,87 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  expect: {
+    timeout: 20_000, // default 5_000
+  },
+
+  testDir: './scenarios',
+  /* Run tests in files in parallel */
+  fullyParallel: false,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: true,
+  /* Retry on CI only */
+  retries: 0,
+  /* Opt out of parallel tests on CI. */
+  workers: 1,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: [
+    ['list'],
+    ['json', {  outputFile: 'test-results.json' }]
+    // ['html'],
+  ],
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('')`. */
+    baseURL: process.env.RHDH_URL || process.env.PLAYWRIGHT_BASEURL,
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
+
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://localhost:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+});

--- a/load-generator/scenarios/Backstage.ts
+++ b/load-generator/scenarios/Backstage.ts
@@ -1,0 +1,31 @@
+import type { Page } from '@playwright/test';
+
+export class Backstage {
+  constructor(public readonly page: Page) {}
+
+  get sidebar() {
+    return this.page.locator('nav');
+  }
+
+  get header() {
+    return this.page.locator(
+      'header, .bui-PluginHeader, .bui-Header, .bui-HeaderPage, .bui-HeaderTop, .bui-HeaderContent',
+    );
+  }
+
+  get pluginHeader() {
+    return this.page.locator('.bui-PluginHeader');
+  }
+
+  get tabs() {
+    return this.page.locator('[role=tablist], div[class*=BackstageHeaderTabs-tabsWrapper]');
+  }
+
+  get content() {
+    return this.page.locator('article, .bui-Header + *, .bui-HeaderPage + *');
+  }
+
+  sidebarItem(name: string) {
+    return this.sidebar.getByRole('link', { name, exact: true });
+  }
+}

--- a/load-generator/scenarios/guest-login-home-catalog.spec.ts
+++ b/load-generator/scenarios/guest-login-home-catalog.spec.ts
@@ -1,0 +1,56 @@
+import { test as base, expect } from '@playwright/test';
+
+import { Backstage } from './Backstage';
+
+const test = base.extend<{ backstage: Backstage }>({
+  backstage: ({ page }, use) => use(new Backstage(page)),
+});
+
+const loops = 100; // TODO: use an env var to override this
+
+for (let i = 1; i <= loops; i++) {
+  test(`run ${i} of ${loops}`, async ({ backstage, page }) => {
+    await test.step('login', async () => {
+      await page.goto('/');
+      await expect(page.getByRole('button', { name: 'Enter' })).toBeVisible();
+    });
+
+    await test.step('home', async () => {
+      await page.getByRole('button', { name: 'Enter' }).click();
+      await expect(backstage.header.getByText('Welcome back!')).toBeVisible();
+      await expect(backstage.content.getByText('Get started')).toBeVisible();
+      await expect(backstage.content.getByText('Explore Your Software Catalog')).toBeVisible();
+      await expect(backstage.content.getByText('Explore Templates')).toBeVisible();
+    });
+
+    await test.step('catalog', async () => {
+      await backstage.sidebarItem('Catalog').click();
+      await expect(backstage.header.getByText('Catalog')).toBeVisible();
+      await expect(backstage.content.getByText('All Components (1000)')).toBeVisible();
+      await expect(backstage.content.getByText('Component 1', { exact: true })).toBeVisible();
+    });
+
+    await test.step('component', async () => {
+      await backstage.content.getByText('Component 1', { exact: true }).click();
+      await expect(backstage.header.getByText('Component 1')).toBeVisible();
+      await expect(backstage.content.getByText('About')).toBeVisible();
+      await expect(backstage.content.getByText('Group 1')).toBeVisible();
+      await expect(backstage.content.getByText('System 1')).toBeVisible();
+      await expect(backstage.tabs.getByText('Catalog Tab 1', { exact: true })).toBeVisible();
+    });
+
+    await test.step('catalog-tab-n', async () => {
+      await backstage.tabs.getByText('Catalog Tab 1', { exact: true }).click();
+      await expect(backstage.header.getByText('Component 1')).toBeVisible();
+      await expect(backstage.content.getByText('Catalog Tab N')).toBeVisible();
+      await expect(backstage.content.getByText('Example User List')).toBeVisible();
+    });
+
+    await test.step('page-n', async () => {
+      await backstage.sidebar.getByText('Page 1', { exact: true }).click();
+      await expect(backstage.header.getByText('Welcome to page-1!')).toBeVisible();
+      await expect(backstage.content.getByText('Information card')).toBeVisible();
+      await expect(backstage.content.getByText('Example User List')).toBeVisible();
+    });
+  });
+}

--- a/load-generator/scripts/analyse.mts
+++ b/load-generator/scripts/analyse.mts
@@ -1,0 +1,80 @@
+import { readFileSync } from 'node:fs';
+
+import type { JSONReport } from '@playwright/test/reporter';
+
+const filename = 'test-results.json';
+
+console.log(`Analyse ${filename}`);
+
+const report: JSONReport = JSON.parse(readFileSync(filename, 'utf-8'));
+
+const stepDurations = new Map<string, number[]>();
+
+for (const suite of report.suites) {
+  for (const spec of suite.specs) {
+    if (!spec.ok) {
+      console.warn(`Unexpected test spec "${spec.ok}" in "${spec.title}"`);
+      continue;
+    }
+    for (const test of spec.tests) {
+      if (test.status !== 'expected') {
+        console.warn(`Unexpected test status "${test.status}" in "${spec.title}"`);
+        continue;
+      }
+      for (const result of test.results) {
+        if (result.status !== 'passed') {
+          console.warn(`Unexpected test result status (${result.status}) in "${spec.title}"`);
+          continue;
+        }
+        if (result.steps) {
+          for (const step of result.steps) {
+            const durations = stepDurations.get(step.title) ?? [];
+            durations.push(step.duration);
+            stepDurations.set(step.title, durations);
+          }
+          const durations = stepDurations.get('all') ?? [];
+          durations.push(result.duration);
+          stepDurations.set('all', durations);
+        }
+      }
+    }
+  }
+}
+
+function percentile(sorted: number[], p: number): number {
+  const idx = (p / 100) * (sorted.length - 1);
+  const lower = Math.floor(idx);
+  const upper = Math.ceil(idx);
+  if (lower === upper) return sorted[lower];
+  return sorted[lower] + (sorted[upper] - sorted[lower]) * (idx - lower);
+}
+
+console.log('');
+console.log(
+  'Step'.padEnd(20),
+  'Count'.padStart(10),
+  'Avg'.padStart(10),
+  'P95'.padStart(10),
+  'Min'.padStart(10),
+  'Max'.padStart(10),
+);
+console.log('-'.repeat(75));
+
+for (const [title, durations] of stepDurations) {
+  const sorted = durations.slice().sort((a, b) => a - b);
+  const avg = durations.reduce((s, d) => s + d, 0) / durations.length;
+  const p95 = percentile(sorted, 95);
+  const min = sorted[0];
+  const max = sorted[sorted.length - 1];
+
+  console.log(
+    title.padEnd(20),
+    String(durations.length).padStart(10),
+    `${avg.toFixed(0)}ms`.padStart(10),
+    `${p95.toFixed(0)}ms`.padStart(10),
+    `${min}ms`.padStart(10),
+    `${max}ms`.padStart(10),
+  );
+}
+
+console.log('');


### PR DESCRIPTION
A load generator that can be started locally (and later also in a container image) to run it directly on a cluster.

This is not replace any 'real' performance tests or our Red Hat performance team. The goal is to make results reproducible and easier testable on smaller test environments.

To run it:

```
cd load-generator
npm ci
export RHDH_URL=...
npm test
```

The npm test runs a playwright script (see scenarios) that runs currently 100 test runs in a sequence. There is parallel tests or virtual users, yet. After the playwright test finish it runs automatically a simple analyse script that output something like this:

```
Step                      Count        Avg        P95        Min        Max
---------------------------------------------------------------------------
login                       100     6661ms     7387ms     6194ms     8564ms
home                        100     1419ms     1905ms     1087ms     1997ms
catalog                     100     1361ms     1454ms     1011ms     1861ms
component                   100      689ms      776ms      543ms     1214ms
catalog-tab-n               100      982ms     1071ms      425ms     2054ms
page-n                      100      982ms     1424ms      881ms     1916ms
all                         100    12126ms    13590ms    10686ms    14515ms
```