### PR TITLE
Add Dependabot config for GitHub Actions and load-generator npm deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /load-generator
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Excludes plugins/ directories by not listing them.