### PR TITLE
Simplify test plugin titles by inlining display names

### DIFF
--- a/plugins/backstage-1.42/plugins/catalog-tab-n/src/components/ExampleComponent/ExampleComponent.test.tsx
+++ b/plugins/backstage-1.42/plugins/catalog-tab-n/src/components/ExampleComponent/ExampleComponent.test.tsx
@@ -22,7 +22,7 @@ describe('ExampleComponent', () => {
   it('should render', async () => {
     await renderInTestApp(<ExampleComponent />);
     expect(
-      screen.getByText('Welcome to catalog-tab-n!'),
+      screen.getByText('Welcome to Catalog Tab N!'),
     ).toBeInTheDocument();
   });
 });

--- a/plugins/backstage-1.42/plugins/page-n/src/components/ExampleComponent/ExampleComponent.test.tsx
+++ b/plugins/backstage-1.42/plugins/page-n/src/components/ExampleComponent/ExampleComponent.test.tsx
@@ -22,7 +22,7 @@ describe('ExampleComponent', () => {
   it('should render', async () => {
     await renderInTestApp(<ExampleComponent />);
     expect(
-      screen.getByText('Welcome to page-n!'),
+      screen.getByText('Welcome to Page N!'),
     ).toBeInTheDocument();
   });
 });

--- a/plugins/backstage-1.42/plugins/page-n/src/components/ExampleComponent/ExampleComponent.tsx
+++ b/plugins/backstage-1.42/plugins/page-n/src/components/ExampleComponent/ExampleComponent.tsx
@@ -12,7 +12,7 @@ import { ExampleFetchComponent } from '../ExampleFetchComponent';
 
 export const ExampleComponent = () => (
   <Page themeId="tool">
-    <Header title="Welcome to page-n!" subtitle="Optional subtitle">
+    <Header title="Welcome to Page N!" subtitle="Optional subtitle">
       <HeaderLabel label="Owner" value="Team X" />
       <HeaderLabel label="Lifecycle" value="Alpha" />
     </Header>

--- a/plugins/backstage-1.45/plugins/catalog-tab-n/src/components/ExampleComponent/ExampleComponent.test.tsx
+++ b/plugins/backstage-1.45/plugins/catalog-tab-n/src/components/ExampleComponent/ExampleComponent.test.tsx
@@ -22,7 +22,7 @@ describe('ExampleComponent', () => {
   it('should render', async () => {
     await renderInTestApp(<ExampleComponent />);
     expect(
-      screen.getByText('Welcome to catalog-tab-n!'),
+      screen.getByText('Welcome to Catalog Tab N!'),
     ).toBeInTheDocument();
   });
 });

--- a/plugins/backstage-1.45/plugins/page-n/src/components/ExampleComponent/ExampleComponent.test.tsx
+++ b/plugins/backstage-1.45/plugins/page-n/src/components/ExampleComponent/ExampleComponent.test.tsx
@@ -22,7 +22,7 @@ describe('ExampleComponent', () => {
   it('should render', async () => {
     await renderInTestApp(<ExampleComponent />);
     expect(
-      screen.getByText('Welcome to page-n!'),
+      screen.getByText('Welcome to Page N!'),
     ).toBeInTheDocument();
   });
 });

--- a/plugins/backstage-1.45/plugins/page-n/src/components/ExampleComponent/ExampleComponent.tsx
+++ b/plugins/backstage-1.45/plugins/page-n/src/components/ExampleComponent/ExampleComponent.tsx
@@ -12,7 +12,7 @@ import { ExampleFetchComponent } from '../ExampleFetchComponent';
 
 export const ExampleComponent = () => (
   <Page themeId="tool">
-    <Header title="Welcome to page-n!" subtitle="Optional subtitle">
+    <Header title="Welcome to Page N!" subtitle="Optional subtitle">
       <HeaderLabel label="Owner" value="Team X" />
       <HeaderLabel label="Lifecycle" value="Alpha" />
     </Header>

--- a/plugins/backstage-1.49/plugins/catalog-tab-n/src/alpha/plugin.tsx
+++ b/plugins/backstage-1.49/plugins/catalog-tab-n/src/alpha/plugin.tsx
@@ -1,18 +1,11 @@
 import { createFrontendPlugin } from '@backstage/frontend-plugin-api';
 import { EntityContentBlueprint } from '@backstage/plugin-catalog-react/alpha';
 
-const PLUGIN_ID = 'catalog-tab-n';
-
-function catalogTabDisplayTitle(pluginId: string): string {
-  const suffix = pluginId.replace(/^catalog-tab-/, '');
-  return `Catalog Tab ${suffix === 'n' ? 'N' : suffix}`;
-}
-
 export const EntityCatalogCard: any = EntityContentBlueprint.make({
   name: 'EntityCatalogCard',
   params: {
-    path: PLUGIN_ID,
-    title: catalogTabDisplayTitle(PLUGIN_ID),
+    path: 'catalog-tab-n',
+    title: 'Catalog Tab N',
     loader: () =>
       import('../components/ExampleComponent').then(m => (
         <m.ExampleComponent />
@@ -21,6 +14,6 @@ export const EntityCatalogCard: any = EntityContentBlueprint.make({
 });
 
 export const catalogTabPlugin = createFrontendPlugin({
-  pluginId: PLUGIN_ID,
+  pluginId: 'catalog-tab-n',
   extensions: [EntityCatalogCard],
 });

--- a/plugins/backstage-1.49/plugins/catalog-tab-n/src/components/ExampleComponent/ExampleComponent.test.tsx
+++ b/plugins/backstage-1.49/plugins/catalog-tab-n/src/components/ExampleComponent/ExampleComponent.test.tsx
@@ -22,7 +22,7 @@ describe('ExampleComponent', () => {
   it('should render', async () => {
     await renderInTestApp(<ExampleComponent />);
     expect(
-      screen.getByText('Welcome to catalog-tab-n!'),
+      screen.getByText('Welcome to Catalog Tab N!'),
     ).toBeInTheDocument();
   });
 });

--- a/plugins/backstage-1.49/plugins/page-n/src/alpha/plugin.tsx
+++ b/plugins/backstage-1.49/plugins/page-n/src/alpha/plugin.tsx
@@ -6,18 +6,11 @@ import ExtensionIcon from '@material-ui/icons/Extension';
 
 import { rootRouteRef } from './routes';
 
-const PLUGIN_ID = 'page-n';
-
-function pageDisplayTitle(pluginId: string): string {
-  const suffix = pluginId.replace(/^page-/, '');
-  return `Page ${suffix === 'n' ? 'N' : suffix}`;
-}
-
 export const page: any = PageBlueprint.make({
   params: {
-    path: `/${PLUGIN_ID}`,
+    path: `/page-n`,
     routeRef: rootRouteRef,
-    title: pageDisplayTitle(PLUGIN_ID),
+    title: 'Page N',
     icon: <ExtensionIcon />,
     loader: () =>
       import('../components/ExampleComponent').then(m => (
@@ -27,6 +20,6 @@ export const page: any = PageBlueprint.make({
 });
 
 export const pagePlugin = createFrontendPlugin({
-  pluginId: PLUGIN_ID,
+  pluginId: 'page-n',
   extensions: [page],
 });

--- a/plugins/backstage-1.49/plugins/page-n/src/components/ExampleComponent/ExampleComponent.test.tsx
+++ b/plugins/backstage-1.49/plugins/page-n/src/components/ExampleComponent/ExampleComponent.test.tsx
@@ -22,7 +22,7 @@ describe('ExampleComponent', () => {
   it('should render', async () => {
     await renderInTestApp(<ExampleComponent />);
     expect(
-      screen.getByText('Welcome to page-n!'),
+      screen.getByText('Welcome to Page N!'),
     ).toBeInTheDocument();
   });
 });

--- a/plugins/backstage-1.49/plugins/page-n/src/components/ExampleComponent/ExampleComponent.tsx
+++ b/plugins/backstage-1.49/plugins/page-n/src/components/ExampleComponent/ExampleComponent.tsx
@@ -12,7 +12,7 @@ import { ExampleFetchComponent } from '../ExampleFetchComponent';
 
 export const ExampleComponent = () => (
   <Page themeId="tool">
-    <Header title="Welcome to page-n!" subtitle="Optional subtitle">
+    <Header title="Welcome to Page N!" subtitle="Optional subtitle">
       <HeaderLabel label="Owner" value="Team X" />
       <HeaderLabel label="Lifecycle" value="Alpha" />
     </Header>

--- a/plugins/backstage-1.52/plugins/catalog-tab-n/src/alpha/plugin.tsx
+++ b/plugins/backstage-1.52/plugins/catalog-tab-n/src/alpha/plugin.tsx
@@ -1,18 +1,11 @@
 import { createFrontendPlugin } from '@backstage/frontend-plugin-api';
 import { EntityContentBlueprint } from '@backstage/plugin-catalog-react/alpha';
 
-const PLUGIN_ID = 'catalog-tab-n';
-
-function catalogTabDisplayTitle(pluginId: string): string {
-  const suffix = pluginId.replace(/^catalog-tab-/, '');
-  return `Catalog Tab ${suffix === 'n' ? 'N' : suffix}`;
-}
-
 export const EntityCatalogCard: any = EntityContentBlueprint.make({
   name: 'EntityCatalogCard',
   params: {
-    path: PLUGIN_ID,
-    title: catalogTabDisplayTitle(PLUGIN_ID),
+    path: 'catalog-tab-n',
+    title: 'Catalog Tab N',
     loader: () =>
       import('../components/ExampleComponent').then(m => (
         <m.ExampleComponent />
@@ -21,6 +14,6 @@ export const EntityCatalogCard: any = EntityContentBlueprint.make({
 });
 
 export const catalogTabPlugin = createFrontendPlugin({
-  pluginId: PLUGIN_ID,
+  pluginId: 'catalog-tab-n',
   extensions: [EntityCatalogCard],
 });

--- a/plugins/backstage-1.52/plugins/catalog-tab-n/src/components/ExampleComponent/ExampleComponent.test.tsx
+++ b/plugins/backstage-1.52/plugins/catalog-tab-n/src/components/ExampleComponent/ExampleComponent.test.tsx
@@ -22,7 +22,7 @@ describe('ExampleComponent', () => {
   it('should render', async () => {
     await renderInTestApp(<ExampleComponent />);
     expect(
-      screen.getByText('Welcome to catalog-tab-n!'),
+      screen.getByText('Welcome to Catalog Tab N!'),
     ).toBeInTheDocument();
   });
 });

--- a/plugins/backstage-1.52/plugins/page-n/src/alpha/plugin.tsx
+++ b/plugins/backstage-1.52/plugins/page-n/src/alpha/plugin.tsx
@@ -6,18 +6,11 @@ import ExtensionIcon from '@material-ui/icons/Extension';
 
 import { rootRouteRef } from './routes';
 
-const PLUGIN_ID = 'page-n';
-
-function pageDisplayTitle(pluginId: string): string {
-  const suffix = pluginId.replace(/^page-/, '');
-  return `Page ${suffix === 'n' ? 'N' : suffix}`;
-}
-
 export const page: any = PageBlueprint.make({
   params: {
-    path: `/${PLUGIN_ID}`,
+    path: `/page-n`,
     routeRef: rootRouteRef,
-    title: pageDisplayTitle(PLUGIN_ID),
+    title: 'Page N',
     icon: <ExtensionIcon />,
     loader: () =>
       import('../components/ExampleComponent').then(m => <m.ExampleComponent />),
@@ -25,6 +18,6 @@ export const page: any = PageBlueprint.make({
 });
 
 export const pagePlugin = createFrontendPlugin({
-  pluginId: PLUGIN_ID,
+  pluginId: 'page-n',
   extensions: [page],
 });

--- a/plugins/backstage-1.52/plugins/page-n/src/components/ExampleComponent/ExampleComponent.test.tsx
+++ b/plugins/backstage-1.52/plugins/page-n/src/components/ExampleComponent/ExampleComponent.test.tsx
@@ -22,7 +22,7 @@ describe('ExampleComponent', () => {
   it('should render', async () => {
     await renderInTestApp(<ExampleComponent />);
     expect(
-      screen.getByText('Welcome to page-n!'),
+      screen.getByText('Welcome to Page N!'),
     ).toBeInTheDocument();
   });
 });

--- a/plugins/backstage-1.52/plugins/page-n/src/components/ExampleComponent/ExampleComponent.tsx
+++ b/plugins/backstage-1.52/plugins/page-n/src/components/ExampleComponent/ExampleComponent.tsx
@@ -12,7 +12,7 @@ import { ExampleFetchComponent } from '../ExampleFetchComponent';
 
 export const ExampleComponent = () => (
   <Page themeId="tool">
-    <Header title="Welcome to page-n!" subtitle="Optional subtitle">
+    <Header title="Welcome to Page N!" subtitle="Optional subtitle">
       <HeaderLabel label="Owner" value="Team X" />
       <HeaderLabel label="Lifecycle" value="Alpha" />
     </Header>


### PR DESCRIPTION
## Summary
- Replace computed `catalogTabDisplayTitle` and `pageDisplayTitle` helper functions with inline string literals in NFS plugin definitions (backstage-1.49, 1.52)
- Use proper title casing ("Page N", "Catalog Tab N") in component headers and test assertions across all Backstage version variants (1.42, 1.45, 1.49, 1.52)

## Test plan
- [ ] Verify `yarn build` passes for all affected plugin workspaces
- [ ] Verify `yarn test` passes for all affected plugin workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)