### PR TITLE
Add K8s Job for load testing and improve test scenarios

### DIFF
--- a/load-generator/k8s/job.yaml
+++ b/load-generator/k8s/job.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: rhdh-loadtest-
+spec:
+  ttlSecondsAfterFinished: 86400
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: loadtest
+          image: quay.io/rhdh-community/rhdh-loadtest-generator
+          env:
+            - name: COREPACK_HOME
+              value: /tmp/corepack
+            - name: HOME
+              value: /tmp
+          command: ["yarn", "playwright", "test", "--output", "/tmp/test-results"]

--- a/load-generator/k8s/run.sh
+++ b/load-generator/k8s/run.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+NAMESPACE=rhdh-loadtest
+TIMEOUT=1800s
+
+kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Creating Job..."
+JOB_NAME=$(
+  kubectl create --dry-run=client -o yaml -n "$NAMESPACE" -f "$SCRIPT_DIR/job.yaml" |
+  kubectl set env -f - --local -o yaml \
+    RHDH_URL="${RHDH_URL:-}" \
+    LOOPS="${LOOPS:-}" |
+  kubectl create -n "$NAMESPACE" -f - -o jsonpath='{.metadata.name}'
+)
+echo "Job: $JOB_NAME"
+
+echo "Waiting for Job to complete or fail..."
+kubectl wait -n "$NAMESPACE" --for=condition=complete --timeout="$TIMEOUT" "job/$JOB_NAME" &
+PID_COMPLETE=$!
+kubectl wait -n "$NAMESPACE" --for=condition=failed --timeout="$TIMEOUT" "job/$JOB_NAME" &
+PID_FAILED=$!
+
+wait -n "$PID_COMPLETE" "$PID_FAILED"
+kill "$PID_COMPLETE" "$PID_FAILED" 2>/dev/null || true
+wait "$PID_COMPLETE" "$PID_FAILED" 2>/dev/null || true
+
+echo "Fetching logs from Pod(s)..."
+kubectl logs -n "$NAMESPACE" "job/$JOB_NAME" --all-containers
+
+if kubectl wait -n "$NAMESPACE" --for=condition=failed --timeout=0 "job/$JOB_NAME" 2>/dev/null; then
+    echo "Job failed!"
+    exit 1
+fi

--- a/load-generator/playwright.config.ts
+++ b/load-generator/playwright.config.ts
@@ -9,14 +9,19 @@ import { defineConfig, devices } from '@playwright/test';
 // dotenv.config({ path: path.resolve(__dirname, '.env') });
 
 const nfs = (process.env.RHDH_FRONTEND ?? 'ofs').toLowerCase() === 'nfs';
+
 const testMatch =
   nfs ? 'guest-login-home-catalog-nfs.spec.ts' : 'guest-login-home-catalog.spec.ts';
+
 // NFS (module federation) needs longer waits for remotes to load
 const testTimeout = Number(
   process.env.PLAYWRIGHT_TEST_TIMEOUT ?? (nfs ? 120_000 : 30_000),
 );
 const expectTimeout = Number(
   process.env.PLAYWRIGHT_EXPECT_TIMEOUT ?? (nfs ? 120_000 : 20_000),
+);
+const navigationTimeout = Number(
+  process.env.PLAYWRIGHT_NAVIGATION_TIMEOUT ?? (nfs ? 120_000 : 30_000),
 );
 
 /**
@@ -49,7 +54,7 @@ export default defineConfig({
     /* Base URL to use in actions like `await page.goto('')`. */
     baseURL: process.env.RHDH_URL || process.env.PLAYWRIGHT_BASEURL,
 
-    navigationTimeout: nfs ? 120_000 : 30_000,
+    navigationTimeout: navigationTimeout,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/load-generator/scenarios/guest-login-home-catalog-nfs.spec.ts
+++ b/load-generator/scenarios/guest-login-home-catalog-nfs.spec.ts
@@ -6,10 +6,10 @@ const test = base.extend<{ backstage: Backstage }>({
   backstage: ({ page }, use) => use(new Backstage(page)),
 });
 
-const loops = Number(process.env.LOOPS ?? 100);
+const loops = Number(process.env.LOOPS ?? 1);
 
 for (let i = 1; i <= loops; i++) {
-  test(`run ${i} of ${loops}`, async ({ backstage, page }) => {
+  test(`run ${i} of ${loops}`, { tag: '@nfs' }, async ({ backstage, page }) => {
     await test.step("login", async () => {
       await page.goto("/");
       await expect(page.getByRole("button", { name: "Enter" })).toBeVisible();
@@ -58,7 +58,7 @@ for (let i = 1; i <= loops; i++) {
     await test.step("page-n", async () => {
       await backstage.sidebarItem("Page 1").click();
       await expect(
-        backstage.header.getByText("Welcome to page-1!"),
+        backstage.header.getByText("Welcome to Page 1!"),
       ).toBeVisible();
       await expect(
         backstage.content.getByText("Information card"),

--- a/load-generator/scenarios/guest-login-home-catalog.spec.ts
+++ b/load-generator/scenarios/guest-login-home-catalog.spec.ts
@@ -6,10 +6,10 @@ const test = base.extend<{ backstage: Backstage }>({
   backstage: ({ page }, use) => use(new Backstage(page)),
 });
 
-const loops = Number(process.env.LOOPS ?? 100);
+const loops = Number(process.env.LOOPS ?? 1);
 
 for (let i = 1; i <= loops; i++) {
-  test(`run ${i} of ${loops}`, async ({ backstage, page }) => {
+  test(`run ${i} of ${loops}`, { tag: '@ofs' }, async ({ backstage, page }) => {
     await test.step('login', async () => {
       await page.goto('/');
       await expect(page.getByRole('button', { name: 'Enter' })).toBeVisible();
@@ -42,13 +42,13 @@ for (let i = 1; i <= loops; i++) {
     await test.step('catalog-tab-n', async () => {
       await backstage.tabs.getByText('Catalog Tab 1', { exact: true }).click();
       await expect(backstage.header.getByText('Component 1')).toBeVisible();
-      await expect(backstage.content.getByText('Catalog Tab N')).toBeVisible();
+      await expect(backstage.content.getByText('Catalog Tab 1')).toBeVisible();
       await expect(backstage.content.getByText('Example User List')).toBeVisible();
     });
 
     await test.step('page-n', async () => {
       await backstage.sidebar.getByText('Page 1', { exact: true }).click();
-      await expect(backstage.header.getByText('Welcome to page-1!')).toBeVisible();
+      await expect(backstage.header.getByText('Welcome to Page 1!')).toBeVisible();
       await expect(backstage.content.getByText('Information card')).toBeVisible();
       await expect(backstage.content.getByText('Example User List')).toBeVisible();
     });


### PR DESCRIPTION
## Summary
- Add Kubernetes Job manifest and `run.sh` script for running load tests on a cluster
- Make `navigationTimeout` configurable via `PLAYWRIGHT_NAVIGATION_TIMEOUT` env var
- Fix test assertions to match updated plugin titles (e.g. `Page 1` instead of `page-1`, `Catalog Tab 1` instead of `Catalog Tab N`)
- Add `@ofs`/`@nfs` test tags to scenarios
- Default `LOOPS` to 1 for local development (was 100)

## Test plan
- [ ] Verify K8s Job runs successfully on a cluster with `RHDH_URL` set
- [ ] Run load tests locally with default `LOOPS=1`
- [ ] Confirm NFS and OFS scenarios pass with updated assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)