### PR TITLE
Fix "No tests found" when LOOPS env var is empty string

### DIFF
--- a/load-generator/scenarios/guest-login-home-catalog-nfs.spec.ts
+++ b/load-generator/scenarios/guest-login-home-catalog-nfs.spec.ts
@@ -6,7 +6,7 @@ const test = base.extend<{ backstage: Backstage }>({
   backstage: ({ page }, use) => use(new Backstage(page)),
 });
 
-const loops = Number(process.env.LOOPS ?? 1);
+const loops = Number(process.env.LOOPS || 1);
 
 for (let i = 1; i <= loops; i++) {
   test(`run ${i} of ${loops}`, { tag: '@nfs' }, async ({ backstage, page }) => {

--- a/load-generator/scenarios/guest-login-home-catalog.spec.ts
+++ b/load-generator/scenarios/guest-login-home-catalog.spec.ts
@@ -6,7 +6,7 @@ const test = base.extend<{ backstage: Backstage }>({
   backstage: ({ page }, use) => use(new Backstage(page)),
 });
 
-const loops = Number(process.env.LOOPS ?? 1);
+const loops = Number(process.env.LOOPS || 1);
 
 for (let i = 1; i <= loops; i++) {
   test(`run ${i} of ${loops}`, { tag: '@ofs' }, async ({ backstage, page }) => {


### PR DESCRIPTION
## Summary
- The K8s job passes `LOOPS=""` (empty string) via `kubectl set env` when the variable isn't defined in the user's shell
- The `??` (nullish coalescing) operator only guards against `null`/`undefined`, not empty string — so `Number("")` evaluates to `0`, creating zero test cases
- Switched to `||` (logical OR) in both spec files so empty string also falls back to `1`

## Test plan
- [x] Reproduced locally: `podman run --rm -e LOOPS="" quay.io/rhdh-community/rhdh-loadtest-generator yarn playwright test` → "Error: No tests found"
- [x] Verified fix: `LOOPS="" yarn playwright test --list` → "Total: 1 test in 1 file"
- [ ] Run `./k8s/run.sh` against a cluster after rebuilding the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)