### PR TITLE
Add network stats logging and throttling support

### DIFF
--- a/load-generator/k8s/job.yaml
+++ b/load-generator/k8s/job.yaml
@@ -16,4 +16,4 @@ spec:
               value: "true"
             - name: PLAYWRIGHT_JSON_OUTPUT_FILE
               value: /tmp/playwright/test-results.json
-          command: ["sh", "-c", "yarn playwright test --output /tmp/playwright && yarn analyse"]
+          command: ["sh", "-c", "yarn playwright test --output /tmp/playwright/test-results && yarn analyse"]

--- a/load-generator/scenarios/guest-login-home-catalog-nfs.spec.ts
+++ b/load-generator/scenarios/guest-login-home-catalog-nfs.spec.ts
@@ -1,6 +1,8 @@
 import { test as base, expect } from "@playwright/test";
 
 import { Backstage } from "./Backstage";
+import { addNetworkListeners } from './network-stats';
+import { setupNetworkThrottling } from './network-throttling';
 
 const test = base.extend<{ backstage: Backstage }>({
   backstage: ({ page }, use) => use(new Backstage(page)),
@@ -9,7 +11,10 @@ const test = base.extend<{ backstage: Backstage }>({
 const loops = Number(process.env.LOOPS || 1);
 
 for (let i = 1; i <= loops; i++) {
-  test(`run ${i} of ${loops}`, { tag: '@nfs' }, async ({ backstage, page }) => {
+  test(`run ${i} of ${loops}`, { tag: '@nfs' }, async ({ backstage, page, context }) => {
+    const networkListeners = await addNetworkListeners(page);
+    await setupNetworkThrottling(context);
+
     await test.step("login", async () => {
       await page.goto("/");
       await expect(page.getByRole("button", { name: "Enter" })).toBeVisible();
@@ -67,5 +72,7 @@ for (let i = 1; i <= loops; i++) {
         backstage.content.getByText("Example User List"),
       ).toBeVisible();
     });
+
+    networkListeners.logStatsAndErrors();
   });
 }

--- a/load-generator/scenarios/guest-login-home-catalog.spec.ts
+++ b/load-generator/scenarios/guest-login-home-catalog.spec.ts
@@ -1,6 +1,8 @@
 import { test as base, expect } from '@playwright/test';
 
 import { Backstage } from './Backstage';
+import { addNetworkListeners } from './network-stats';
+import { setupNetworkThrottling } from './network-throttling';
 
 const test = base.extend<{ backstage: Backstage }>({
   backstage: ({ page }, use) => use(new Backstage(page)),
@@ -9,7 +11,10 @@ const test = base.extend<{ backstage: Backstage }>({
 const loops = Number(process.env.LOOPS || 1);
 
 for (let i = 1; i <= loops; i++) {
-  test(`run ${i} of ${loops}`, { tag: '@ofs' }, async ({ backstage, page }) => {
+  test(`run ${i} of ${loops}`, { tag: '@ofs' }, async ({ backstage, page, context }) => {
+    const networkListeners = await addNetworkListeners(page);
+    await setupNetworkThrottling(context);
+    
     await test.step('login', async () => {
       await page.goto('/');
       await expect(page.getByRole('button', { name: 'Enter' })).toBeVisible();
@@ -52,5 +57,7 @@ for (let i = 1; i <= loops; i++) {
       await expect(backstage.content.getByText('Information card')).toBeVisible();
       await expect(backstage.content.getByText('Example User List')).toBeVisible();
     });
+
+    networkListeners.logStatsAndErrors();
   });
 }

--- a/load-generator/scenarios/network-stats.ts
+++ b/load-generator/scenarios/network-stats.ts
@@ -1,0 +1,65 @@
+import type { Page, ConsoleMessage, Request, Response } from '@playwright/test';
+
+interface LogResult {
+  logStatsAndErrors: () => void;
+}
+
+export const addNetworkListeners = async (page: Page): Promise<LogResult> => {
+  const consoleMessages = [] as ConsoleMessage[];
+  const requests = [] as Request[];
+  const requestsFailed = [] as Request[];
+  const requestsFinished = [] as Request[];
+  const responses = [] as Response[];
+  
+  page.on('console', (msg) => {
+    console.log(`Browser console.${msg.type()}: ${msg.text()}`);
+    consoleMessages.push(msg);
+  });
+  
+  page.on('request', (req) => requests.push(req));
+  page.on('requestfailed', (req) => requestsFailed.push(req));
+  page.on('requestfinished', (req) => requestsFinished.push(req));
+  page.on('response', (resp) => responses.push(resp));
+
+  const logStatsAndErrors = () => {
+    const stats = {
+      consoleMessages: consoleMessages.length,
+      requests: requests.length,
+      requestsFailed: requestsFailed.length,
+      requestsFinished: requestsFinished.length,
+      responses: responses.length,
+      perDomain: {} as Record<string, number>,
+      perResourceType: {} as Record<string, number>,
+      perStatusCode: {} as Record<number, number>,
+    };
+    
+    const pageHostname = new URL(page.url()).hostname;
+    responses.forEach((resp) => {
+      const url = new URL(resp.url());
+      const hostname = pageHostname === url.hostname ? 'same-domain' : url.hostname;
+      stats.perDomain[hostname] = (stats.perDomain[hostname] || 0) + 1;
+      const resourceType = resp.request().resourceType();
+      stats.perResourceType[resourceType] = (stats.perResourceType[resourceType] || 0) + 1;
+      const statusCode = resp.status();
+      stats.perStatusCode[statusCode] = (stats.perStatusCode[statusCode] || 0) + 1;
+    });
+
+    console.log('Stats:', stats);
+
+    // Log all request failed
+    requestsFailed.forEach((req) => {
+      console.log(`Request failed: ${req.method()} ${req.url()} - ${req.failure()?.errorText}`);
+    });
+
+    // Log all responses with status code != 200
+    responses.forEach((resp) => {
+      if (resp.status() !== 200) {
+        console.log(`Response with status code != 200: ${resp.status()} ${resp.url()}`);
+      }
+    });
+  };
+
+  return {
+    logStatsAndErrors,
+  }
+};

--- a/load-generator/scenarios/network-throttling.ts
+++ b/load-generator/scenarios/network-throttling.ts
@@ -1,0 +1,96 @@
+import type { BrowserContext } from 'playwright-core';
+
+// Will read the NETWORK_THROTTLING environment variable and set up network throttling accordingly.
+// Fallback to 'none' if the environment variable is not set or invalid.
+type NetworkThrottlingOptions = 'none' | 'fast' | 'medium' | 'slow';
+
+const option = process.env.NETWORK_THROTTLING as NetworkThrottlingOptions || 'none';
+
+  // From CDPSession => Protocol.Network.EmulateNetworkConditionsParams
+export type EmulateNetworkConditionsParameters = {
+  /**
+   * True to emulate internet disconnection.
+   */
+  offline: boolean;
+  /**
+   * Minimum latency from request sent to response headers received (ms).
+   */
+  latency: number;
+  /**
+   * Maximal aggregated download throughput (bytes/sec). -1 disables download throttling.
+   */
+  downloadThroughput: number;
+  /**
+   * Maximal aggregated upload throughput (bytes/sec).  -1 disables upload throttling.
+   */
+  uploadThroughput: number;
+  /**
+   * Connection type if known.
+   */
+  connectionType?: "none"|"cellular2g"|"cellular3g"|"cellular4g"|"bluetooth"|"ethernet"|"wifi"|"wimax"|"other";
+  /**
+   * WebRTC packet loss (percent, 0-100). 0 disables packet loss emulation, 100 drops all the packets.
+   */
+  packetLoss?: number;
+  /**
+   * WebRTC packet queue length (packet). 0 removes any queue length limitations.
+   */
+  packetQueueLength?: number;
+  /**
+   * WebRTC packetReordering feature.
+   */
+  packetReordering?: boolean;
+}
+
+const conditions: Record<string, EmulateNetworkConditionsParameters> = {
+  none: {
+    offline: false,
+    downloadThroughput: -1,
+    uploadThroughput: -1,
+    latency: 0,
+  },
+  fast: {
+    offline: false,
+    downloadThroughput: 10 * 1024 * 1024 / 8, // 10 Mbit/s
+    uploadThroughput: 5 * 1024 * 1024 / 8, // 5 Mbit/s
+    latency: 2,
+    connectionType: 'wifi',
+  },
+  medium: {
+    offline: false,
+    downloadThroughput: 5 * 1024 * 1024 / 8, // 5 Mbit/s
+    uploadThroughput: 2 * 1024 * 1024 / 8, // 2 Mbit/s
+    latency: 5,
+    connectionType: 'wifi',
+  },
+  slow: {
+    offline: false,
+    downloadThroughput: 2 * 1024 * 1024 / 8, // 2 Mbit/s
+    uploadThroughput: 1 * 1024 * 1024 / 8, // 1 Mbit/s
+    latency: 10,
+    connectionType: 'wifi',
+  },
+};
+
+let alreadyConfigured = false;
+
+export const setupNetworkThrottling = async (context: BrowserContext) => {
+  if (alreadyConfigured) {
+    return;
+  }
+  alreadyConfigured = true;
+
+  let condition = conditions[option];
+
+  if (!condition) {
+    console.warn(`Invalid NETWORK_THROTTLING value: ${option}. Falling back to 'none'.`);
+    condition = conditions.none;
+  } else if (option === 'none') {
+    console.log('Network throttling is disabled');
+  } else {
+    console.log('Network throttling is enabled with option:', option, '=>', condition);
+  }
+
+  const cdpSession = await context.newCDPSession(await context.pages()[0]);
+  await cdpSession.send('Network.emulateNetworkConditions', condition);
+};


### PR DESCRIPTION
## Summary
- Add `network-stats` helper that logs request/response counts, per-domain and per-status-code breakdowns, failed requests, and browser console messages
- Add `network-throttling` helper with configurable presets (`fast`/`medium`/`slow`) controlled via `NETWORK_THROTTLING` env var using CDP
- Integrate both into OFS and NFS test scenarios
- Fix K8s job output path for test results

## Test plan
- [ ] Run load tests locally with `NETWORK_THROTTLING=none` (default) and verify stats are logged
- [ ] Run with `NETWORK_THROTTLING=fast` and verify throttling is applied
- [ ] Verify K8s job produces test results at the correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)